### PR TITLE
Fix non-functional self variable operand

### DIFF
--- a/Release/_hijack_root/qml/Event/EventCommands/EventCommand357.qml
+++ b/Release/_hijack_root/qml/Event/EventCommands/EventCommand357.qml
@@ -116,6 +116,7 @@ EventCommandBase {
         troopId: root.troopId
         minimumValue: -99999999
         maximumValue: 99999999
+        allowSelfVariableOperand: true
     }
 
     onLoad: {

--- a/Release/_hijack_root/qml/Event/Group_Operand.qml
+++ b/Release/_hijack_root/qml/Event/Group_Operand.qml
@@ -25,6 +25,9 @@ GroupBox {
     property int radioButtonWidth: 100
     property int itemHeight: 28
 
+    // [OneMaker MV] - Self Variable Operand
+    property bool allowSelfVariableOperand: false
+
     ControlsColumn {
         ExclusiveGroup { id: group }
 
@@ -199,13 +202,22 @@ GroupBox {
             gameDataOperandBox.param2 = operandValue3;
             break;
         case 4:
-            radioButton5.checked = true;
+            // [OneMaker MV] - Workaround for EventCommand122 (Control Variables)
+            var selfVarMatch = /^this\.selfVariableValue\((\d+)\)$/.exec(operandValue1);
+            if (!allowSelfVariableOperand &&
+                selfVarMatch && (+selfVarMatch[1] >= 0) && (+selfVarMatch[1] < selfVariableBox.count)
+            ) {
+                radioButton6.checked = true;
+                selfVariableBox.currentIndex = +selfVarMatch[1];
+            } else {
+                radioButton5.checked = true;
+            }
             scriptBox.text = operandValue1;
             break;
         // [OneMaker MV] - Added case 5, self variables 
         case 5:
             radioButton6.checked = true;
-            selfVariableBox.value = operandValue1;
+            selfVariableBox.currentIndex = operandValue1;
             break;
         }
     }
@@ -234,7 +246,13 @@ GroupBox {
             break;
         // [OneMaker MV] - Added case 5, self variables 
         case 5:
-            params.push(selfVariableBox.value);
+            if (allowSelfVariableOperand) {
+                params.push(selfVariableBox.value);
+                break;
+            } else {
+                params[0] = 4;
+                params.push("this.selfVariableValue(" + selfVariableBox.value + ")");
+            }
             break;
         }
         return params;

--- a/Release/_hijack_root/qml/Event/Group_Operand.qml
+++ b/Release/_hijack_root/qml/Event/Group_Operand.qml
@@ -248,7 +248,6 @@ GroupBox {
         case 5:
             if (allowSelfVariableOperand) {
                 params.push(selfVariableBox.value);
-                break;
             } else {
                 params[0] = 4;
                 params.push("this.selfVariableValue(" + selfVariableBox.value + ")");


### PR DESCRIPTION
Fixes a bug where a Control Variables command has non-functional UI for a self variable operand.

For Control Variables, if you select a self variable N, it replaces it with a script operand `this.selfVariableValue(N)`.
It also will parse _exactly_ that script back into a self variable operand in the UI (if N is in bounds), but I can disable this if requested.

Control Self Variables can use a self variable operand as normal.
All other users of `Group_Operand` only display constant and variable operands so no change is needed.