### PR TITLE
Add scrollbars to scripts and comments

### DIFF
--- a/Release/_hijack_root/qml/Event/EventCommands/EventCommand108.qml
+++ b/Release/_hijack_root/qml/Event/EventCommands/EventCommand108.qml
@@ -20,19 +20,12 @@ EventCommandBase {
         title: qsTr("Comment")
         hint: qsTr("Comment text. Has no effect in the game.")
         width: 400 + OneMakerMVSettings.getSetting("windowSizes", "defaultWidthIncrease") // [OneMaker MV] - Window Increased
-        height: fittingHeight(maximumLineCount)
+        height: fittingHeight(Math.min(Math.max(lineCount, 6), 24)) // [OneMaker MV] - Dynamically scale from 6 to 24 lines (+scrollbars)
         selectAllOnFocus: false
-        maximumLineCount: 24 // [OneMaker MV] - Increased by 18
-
-        onKeyPressed: {
-            if (event.key === Qt.Key_Return && isFinalLine()) {
-                root.ok();
-            }
-        }
-
-        function isFinalLine() {
-            return currentLineIndex === maximumLineCount - 1;
-        }
+        // [OneMaker MV] - Removed:
+        // maximumLineCount: 6
+        // onKeyPressed: {
+        // isFinalLine() {
 
         contextMenu: TextEditPopupMenu {
             MenuSeparator { }

--- a/Release/_hijack_root/qml/Event/EventCommands/EventCommand355.qml
+++ b/Release/_hijack_root/qml/Event/EventCommands/EventCommand355.qml
@@ -20,19 +20,12 @@ EventCommandBase {
         title: qsTr("Script")
         hint: qsTr("JavaScript code to be evaluated.")
         width: 400 + OneMakerMVSettings.getSetting("windowSizes", "defaultWidthIncrease") // [OneMaker MV] - Window Increased
-        height: fittingHeight(maximumLineCount)
+        height: fittingHeight(Math.min(Math.max(lineCount, 12), 24)) // [OneMaker MV] - Dynamically scale from 12 to 24 lines (+scrollbars)
         selectAllOnFocus: false
-        maximumLineCount: 36 // [OneMaker MV] - Increased by 24
-
-        onKeyPressed: {
-            if (event.key === Qt.Key_Return && isFinalLine()) {
-                root.ok();
-            }
-        }
-
-        function isFinalLine() {
-            return currentLineIndex === maximumLineCount - 1;
-        }
+        // [OneMaker MV] - Removed:
+        // maximumLineCount: 12
+        // onKeyPressed: {
+        // isFinalLine() {
 
         contextMenu: TextEditPopupMenu {
             MenuSeparator { }


### PR DESCRIPTION
Removes `textArea.maximumLineCount` which enables the default horizontal and vertical scrollbars when needed.
Changes `textArea.height` to automatically scale with added lines up to the old maximum.