### PR TITLE
Fix Event Test (+Common Events and Troops)

### DIFF
--- a/Core Plugin/Geo_ImprovedEventTest.js
+++ b/Core Plugin/Geo_ImprovedEventTest.js
@@ -27,9 +27,12 @@ var beesList_oldLodaDatabase = DataManager.loadDatabase;
 DataManager.loadDatabase = function() {
   // Run Original Function
   beesList_oldLodaDatabase.call(this);
+  const _mapLoader = DataManager._mapLoader;
+  DataManager._mapLoader = (function() { /* prevents error message */ });
   if (DataManager.isEventTest()) {
     DataManager.loadDataFile('$testEventExtra', 'Test_EventExtra.json');
   };
+  DataManager._mapLoader = _mapLoader;
 };
 
 Game_Map.prototype.setupTestEvent = function() {

--- a/Release/_hijack_root/qml/Event/EventCommandListBox.qml
+++ b/Release/_hijack_root/qml/Event/EventCommandListBox.qml
@@ -8,6 +8,7 @@ import "../ObjControls"
 import "../Dialogs"
 import "../Map"
 import "../Singletons"
+import "../_OneMakerMV"
 
 ListBox {
     id: root
@@ -26,6 +27,9 @@ ListBox {
     // [OneMaker MV] - Detect if Improved Event Test plugin is enabled
     property bool improveEventTest: false
 
+    // [OneMaker MV] - Add Map ID and Event ID for Event Test Improvement.
+    property int mapId: DataManager.currentMapId
+    property int eventId: 0
     // [OneMaker MV] - Add Cursor Map X/Y for Event Test Improvement.
     property int mapX: 0
     property int mapY: 0
@@ -492,17 +496,14 @@ ListBox {
 
     function test() {
         // [OneMaker MV] - Detect if the Event Test Fixes plugin is installed
-        var dataArray = DataManager.plugins;
-
-        for (var i = 0; i < dataArray.length; i++) {
-            if (OneMakerMVSettings.detectPluginActivationStatus("Geo_ImprovedEventTest")) {
-                dialogLocation.mapId = mapId;
-                dialogLocation.mapX = object["x"];
-                dialogLocation.mapY = object["y"];
-                dialogLocation.open();
-                improveEventTest = true;
-                return;
-            }
+        if (OneMakerMVSettings.detectPluginActivationStatus("Geo_ImprovedEventTest")) {
+            dialogLocation.mapId = mapId;
+            var object2 = (typeof object === "undefined") ? {} : object;
+            dialogLocation.mapX = object2["x"] || 0;
+            dialogLocation.mapY = object2["y"] || 0;
+            dialogLocation.open();
+            improveEventTest = true;
+            return;
         }
 
         runTest();

--- a/Release/_hijack_root/qml/Event/Layout_EventPage.qml
+++ b/Release/_hijack_root/qml/Event/Layout_EventPage.qml
@@ -161,6 +161,9 @@ GroupBoxRow {
                 list: dataObject ? dataObject.list : []
                 width: 638 + OneMakerMVSettings.getWindowSetting("defaultWidthIncrease") // [OneMaker MV] - Window Increased
                 height: 522 + OneMakerMVSettings.getWindowSetting("defaultHeightIncrease") // [OneMaker MV] - Window Increased
+                // [OneMaker MV] - Add Map ID and Event ID for Event Test Improvement.
+                mapId: root.mapId
+                eventId: eventId
             }
         }
     }


### PR DESCRIPTION
Event tests throw an error on `dev` due to missing `"../_OneMakerMV"` import.
In addition, common event tests and troop event tests would throw an error due to missing `mapId`.
PR fixes both issues.

Includes a bugfix to Geo's plugin that is not needed as of right now since the `Test_EventExtra.json` file will always exist if it's enabled.

Possible future work: Have troop event tests run inside a battle test instead of a regular map event test.